### PR TITLE
fix: correct require_approval property for activation_rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ map(object({
       require_ticket_info                                = optional(bool)
       require_multifactor_authentication                 = optional(bool)
       required_conditional_access_authentication_context = optional(bool)
-      require_approvals                                  = optional(bool)
+      require_approval                                   = optional(bool)
       maximum_duration                                   = optional(string)
       approval_stage = optional(object({
         primary_approver = map(object({

--- a/examples/management_policy/policy.tf
+++ b/examples/management_policy/policy.tf
@@ -21,7 +21,7 @@ locals {
         expire_after        = "P90D"
       }
       activation_rules = {
-        require_approvals                  = true
+        require_approval                   = true
         require_multifactor_authentication = true
         require_ticket_info                = false
         require_justification              = true
@@ -82,7 +82,7 @@ locals {
         expire_after        = "P30D"
       }
       activation_rules = {
-        require_approvals                  = true
+        require_approval                   = true
         require_multifactor_authentication = true
         require_ticket_info                = true
         require_justification              = true

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "management_policies" {
       require_ticket_info                                = optional(bool)
       require_multifactor_authentication                 = optional(bool)
       required_conditional_access_authentication_context = optional(bool)
-      require_approvals                                  = optional(bool)
+      require_approval                                   = optional(bool)
       maximum_duration                                   = optional(string)
       approval_stage = optional(object({
         primary_approver = map(object({


### PR DESCRIPTION
## Description

This small PR corrects what appears to be a bug in the activation_rules specification. I adjusted the variable spec rather than
`main.tf` since it aligns more closely with the API / provider resource definition.


## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have made corresponding changes to the documentation
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `azurerm_role_management_policy` - align variable `require_approval` property with value referenced by resource 


<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #14
